### PR TITLE
Soporte para python 2 y python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ install:
 - pip install python-coveralls
 - pip install coveralls
 language: python
+matrix:
+  allow_failures:
+  - python: '3.5'
 notifications:
   slack: ssipyga:yyz0hyWmiaoGGnprhjqDXUwk
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,12 @@ install:
 - pip install python-coveralls
 - pip install coveralls
 language: python
-matrix:
-  allow_failures:
-  - python: '3.5'
-  - python: '3.6'
-  - python: '3.7'
 notifications:
   slack: ssipyga:yyz0hyWmiaoGGnprhjqDXUwk
 python:
 - '2.7'
 - '3.5'
 - '3.6'
-- '3.7'
 script:
 - nosetests --with-coverage
 - travis-sphinx build --source=docs -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ install:
 - pip install python-coveralls
 - pip install coveralls
 language: python
-matrix:
-  allow_failures:
-  - python: '3.6'
 notifications:
   slack: ssipyga:yyz0hyWmiaoGGnprhjqDXUwk
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ install:
 - pip install python-coveralls
 - pip install coveralls
 language: python
+matrix:
+  allow_failures:
+  - python: '3.6'
 notifications:
   slack: ssipyga:yyz0hyWmiaoGGnprhjqDXUwk
 python:

--- a/data_cleaner/__init__.py
+++ b/data_cleaner/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
-from data_cleaner import DataCleaner
-from georef_api import GeorefWrapper
+from .data_cleaner import DataCleaner
+from .georef_api import GeorefWrapper
 
 __author__ = """Datos Argentina"""
 __email__ = 'datos@modernizacion.gob.ar'

--- a/data_cleaner/capitalizer.py
+++ b/data_cleaner/capitalizer.py
@@ -6,6 +6,7 @@
 import string
 import pandas as pd
 from functools import partial
+import six
 
 
 LOWER_WORDS = [
@@ -54,14 +55,14 @@ def capitalize(string, sep=None, encoding="utf-8", lower_words=None):
     if pd.isnull(string):
         return pd.np.nan
 
-    if type(string) is not str or type(string) is not unicode:
-        string = unicode(string)
+    if not isinstance(string, six.text_type):
+        string = six.u(string)
 
     words = string.split(sep)
     if len(words) == 0:
         return ""
     first_word = words[0].title()
     partial_normalize_word = partial(normalize_word, lower_words=lower_words)
-    normalized_words = [first_word] + map(partial_normalize_word, words[1:])
+    normalized_words = [first_word] + list(map(partial_normalize_word, words[1:]))
 
     return (sep if sep else " ").join(normalized_words)

--- a/data_cleaner/capitalizer.py
+++ b/data_cleaner/capitalizer.py
@@ -7,6 +7,7 @@ import string
 import pandas as pd
 from functools import partial
 import six
+from builtins import str
 
 
 LOWER_WORDS = [
@@ -56,7 +57,7 @@ def capitalize(string, sep=None, encoding="utf-8", lower_words=None):
         return pd.np.nan
 
     if not isinstance(string, six.text_type):
-        string = six.u(string)
+        string = six.u(str(string))
 
     words = string.split(sep)
     if len(words) == 0:

--- a/data_cleaner/capitalizer.py
+++ b/data_cleaner/capitalizer.py
@@ -7,7 +7,6 @@ import string
 import pandas as pd
 from functools import partial
 import six
-from builtins import str
 
 
 LOWER_WORDS = [
@@ -57,13 +56,13 @@ def capitalize(string, sep=None, encoding="utf-8", lower_words=None):
         return pd.np.nan
 
     if not isinstance(string, six.text_type):
-        string = six.u(str(string))
+        string = six.text_type(string)
 
     words = string.split(sep)
     if len(words) == 0:
-        return ""
+        return u""
     first_word = words[0].title()
     partial_normalize_word = partial(normalize_word, lower_words=lower_words)
     normalized_words = [first_word] + list(map(partial_normalize_word, words[1:]))
 
-    return (sep if sep else " ").join(normalized_words)
+    return (sep if sep else u" ").join(normalized_words)

--- a/data_cleaner/capitalizer.py
+++ b/data_cleaner/capitalizer.py
@@ -60,9 +60,9 @@ def capitalize(string, sep=None, encoding="utf-8", lower_words=None):
 
     words = string.split(sep)
     if len(words) == 0:
-        return u""
+        return ""
     first_word = words[0].title()
     partial_normalize_word = partial(normalize_word, lower_words=lower_words)
     normalized_words = [first_word] + list(map(partial_normalize_word, words[1:]))
 
-    return (sep if sep else u" ").join(normalized_words)
+    return (sep if sep else " ").join(normalized_words)

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -25,11 +25,11 @@ import re
 import subprocess
 from functools import partial
 
-from fingerprint_keyer import group_fingerprint_strings
-from fingerprint_keyer import get_best_replacements, replace_by_key
-from capitalizer import capitalize
+from .fingerprint_keyer import group_fingerprint_strings
+from .fingerprint_keyer import get_best_replacements, replace_by_key
+from .capitalizer import capitalize
 
-from georef_api import *
+from .georef_api import *
 
 
 class DuplicatedField(ValueError):

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -24,11 +24,10 @@ import inspect
 import re
 import subprocess
 from functools import partial
-
+from future.utils import iteritems
 from .fingerprint_keyer import group_fingerprint_strings
 from .fingerprint_keyer import get_best_replacements, replace_by_key
 from .capitalizer import capitalize
-
 from .georef_api import *
 
 
@@ -436,7 +435,7 @@ Método que llamó al normalizador de campos: {}
         field = self._normalize_field(field)
         series = self.df[field]
 
-        for new_value, old_values in replacements.iteritems():
+        for new_value, old_values in iteritems(replacements):
             series = series.replace(old_values, new_value)
 
         encoded_series = series.str.encode(self.OUTPUT_ENCODING)
@@ -464,7 +463,7 @@ Método que llamó al normalizador de campos: {}
         field = self._normalize_field(field)
         series = self.df[field]
 
-        for new_value, old_values in replacements.iteritems():
+        for new_value, old_values in iteritems(replacements):
             # for old_value in sorted(old_values, key=len, reverse=True):
             for old_value in old_values:
                 replace_function = partial(self._safe_replace,
@@ -828,7 +827,7 @@ Método que llamó al normalizador de campos: {}
         field_mun = MUN + '_field'
 
         # Verfica que se utilicen keywords válidos por entidad
-        for key, value in filters.iteritems():
+        for key, value in iteritems(filters):
 
             if key not in [field_prov, field_dept, field_mun]:
                 print('"{}" no es un keyword válido.'.format(key))

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -18,7 +18,7 @@ import arrow
 import parsley
 from unidecode import unidecode
 import unicodecsv
-import chardet
+import cchardet
 import warnings
 import inspect
 import re
@@ -146,7 +146,7 @@ class DataCleaner(object):
             str: Codificación del archivo.
         """
         with open(file_path, 'rb') as f:
-            info = chardet.detect(f.read())
+            info = cchardet.detect(f.read())
         return (info['encoding'] if info['confidence'] > 0.75
                 else self.INPUT_DEFAULT_ENCODING)
 

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -115,8 +115,6 @@ class DataCleaner(object):
         # guarda PEGs compiladas para optimizar performance
         self.grammars = {}
 
-        self.save.__func__.__doc__ = pd.DataFrame.to_csv.__func__.__doc__
-
     def _assert_no_duplicates(self, input_path, encoding, sep, quotechar):
 
         if input_path.endswith('.csv'):

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -25,11 +25,13 @@ import re
 import subprocess
 from functools import partial
 from future.utils import iteritems
+import six
+
 from .fingerprint_keyer import group_fingerprint_strings
 from .fingerprint_keyer import get_best_replacements, replace_by_key
 from .capitalizer import capitalize
+
 from .georef_api import *
-import six
 
 
 class DuplicatedField(ValueError):
@@ -180,7 +182,7 @@ class DataCleaner(object):
         if field != norm_field:
             caller_rule = self._get_normalize_field_caller(
                 inspect.currentframe())
-            msg = six.text_type("""
+            msg = """
 
 El campo "{}" no sigue las convenciones para escribir
 campos (sólo se admiten caracteres alfanuméricos ASCII en
@@ -190,7 +192,7 @@ que puede llevar a resultados inesperados.
 
 El nuevo nombre del campo normalizado es: "{}".
 Método que llamó al normalizador de campos: {}
-""").format(field, sep, norm_field, caller_rule)
+""".format(field, sep, norm_field, caller_rule)
             warnings.warn(msg)
 
         return norm_field

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -120,12 +120,12 @@ class DataCleaner(object):
     def _assert_no_duplicates(self, input_path, encoding, sep, quotechar):
 
         if input_path.endswith('.csv'):
-            with open(input_path, 'r') as csvfile:
+            with open(input_path, 'rb') as csvfile:
                 reader = unicodecsv.reader(csvfile,
                                            encoding=encoding,
                                            delimiter=sep,
                                            quotechar=quotechar)
-                fields = reader.next()
+                fields = next(reader, [])
 
                 for col in fields:
                     if fields.count(col) > 1:

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -439,14 +439,12 @@ Método que llamó al normalizador de campos: {}
         for new_value, old_values in iteritems(replacements):
             series = series.replace(old_values, new_value)
 
-        encoded_series = series.str.encode(self.OUTPUT_ENCODING)
-
         if inplace:
             self._update_series(field=field, sufix=sufix,
                                 keep_original=keep_original,
-                                new_series=encoded_series)
+                                new_series=series)
 
-        return encoded_series
+        return series
 
     def reemplazar_string(self, field, replacements, sufix=None,
                           keep_original=False, inplace=False):
@@ -506,7 +504,7 @@ Método que llamó al normalizador de campos: {}
                                 keep_original=keep_original,
                                 new_series=parsed_series)
 
-        return parsed_series.str.encode(self.OUTPUT_ENCODING)
+        return parsed_series
 
     def fecha_simple(self, field, time_format, keep_original=False,
                      inplace=False):
@@ -529,7 +527,7 @@ Método que llamó al normalizador de campos: {}
                                 keep_original=keep_original,
                                 new_series=parsed_series)
 
-        return parsed_series.str.encode(self.OUTPUT_ENCODING)
+        return parsed_series
 
     @staticmethod
     def _parse_datetime(value, time_format):
@@ -586,7 +584,7 @@ Método que llamó al normalizador de campos: {}
                 for field in field_names:
                     self.remover_columnas(field)
 
-        return parsed_series.str.encode(self.OUTPUT_ENCODING)
+        return parsed_series
 
     def string_simple_split(self, field, separators, new_field_names,
                             keep_original=True, inplace=False):

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -46,12 +46,12 @@ class DataCleaner(object):
     reglas de limpieza para operar sobre las columnas del objeto y retornar un
     CSV limplio."""
 
-    OUTPUT_ENCODING = six.u("utf-8")
-    OUTPUT_SEPARATOR = six.u(",")
-    OUTPUT_QUOTECHAR = six.u('"')
-    INPUT_DEFAULT_ENCODING = six.u("utf-8")
-    INPUT_DEFAULT_SEPARATOR = six.u(",")
-    INPUT_DEFAULT_QUOTECHAR = six.u('"')
+    OUTPUT_ENCODING = str("utf-8")
+    OUTPUT_SEPARATOR = str(",")
+    OUTPUT_QUOTECHAR = str('"')
+    INPUT_DEFAULT_ENCODING = str("utf-8")
+    INPUT_DEFAULT_SEPARATOR = str(",")
+    INPUT_DEFAULT_QUOTECHAR = str('"')
     DEFAULT_SUFIX = "normalizado"
 
     def __init__(self, input_path, ignore_dups=False, **kwargs):
@@ -162,7 +162,7 @@ class DataCleaner(object):
             str: Nombre de campo o sufijo de datset normalizado.
         """
         if not isinstance(field, six.string_types):
-            field = six.u(field)
+            field = six.text_type(field)
 
         # reemplaza caracteres que no sean unicode
         norm_field = unidecode(field).strip()
@@ -180,7 +180,7 @@ class DataCleaner(object):
         if field != norm_field:
             caller_rule = self._get_normalize_field_caller(
                 inspect.currentframe())
-            msg = u"""
+            msg = six.text_type("""
 
 El campo "{}" no sigue las convenciones para escribir
 campos (sólo se admiten caracteres alfanuméricos ASCII en
@@ -190,7 +190,7 @@ que puede llevar a resultados inesperados.
 
 El nuevo nombre del campo normalizado es: "{}".
 Método que llamó al normalizador de campos: {}
-""".format(field, sep, norm_field, caller_rule)
+""").format(field, sep, norm_field, caller_rule)
             warnings.warn(msg)
 
         return norm_field
@@ -214,7 +214,7 @@ Método que llamó al normalizador de campos: {}
     @staticmethod
     def _remove_line_breaks(value, replace_char=" "):
         if isinstance(value, six.string_types):
-            return six.u(value).replace('\n', replace_char)
+            return six.text_type(value).replace('\n', replace_char)
         else:
             return value
 
@@ -439,12 +439,14 @@ Método que llamó al normalizador de campos: {}
         for new_value, old_values in iteritems(replacements):
             series = series.replace(old_values, new_value)
 
+        encoded_series = series.str.encode(self.OUTPUT_ENCODING)
+
         if inplace:
             self._update_series(field=field, sufix=sufix,
                                 keep_original=keep_original,
-                                new_series=series)
+                                new_series=encoded_series)
 
-        return series
+        return encoded_series
 
     def reemplazar_string(self, field, replacements, sufix=None,
                           keep_original=False, inplace=False):
@@ -482,7 +484,7 @@ Método que llamó al normalizador de campos: {}
         if pd.isnull(string):
             return pd.np.nan
         else:
-            return six.u(string).replace(old_value, new_value)
+            return six.text_type(string).replace(old_value, new_value)
 
     def fecha_completa(self, field, time_format, keep_original=False,
                        inplace=False):
@@ -504,7 +506,7 @@ Método que llamó al normalizador de campos: {}
                                 keep_original=keep_original,
                                 new_series=parsed_series)
 
-        return parsed_series
+        return parsed_series.str.encode(self.OUTPUT_ENCODING)
 
     def fecha_simple(self, field, time_format, keep_original=False,
                      inplace=False):
@@ -527,7 +529,7 @@ Método que llamó al normalizador de campos: {}
                                 keep_original=keep_original,
                                 new_series=parsed_series)
 
-        return parsed_series
+        return parsed_series.str.encode(self.OUTPUT_ENCODING)
 
     @staticmethod
     def _parse_datetime(value, time_format):
@@ -571,7 +573,7 @@ Método que llamó al normalizador de campos: {}
         time_format = " ".join([field[1] for field in fields])
 
         concat_series = self.df[field_names].apply(
-            lambda x: u' '.join(x.map(six.text_type)),
+            lambda x: ' '.join(x.map(six.text_type)),
             axis=1
         )
 
@@ -584,7 +586,7 @@ Método que llamó al normalizador de campos: {}
                 for field in field_names:
                     self.remover_columnas(field)
 
-        return parsed_series
+        return parsed_series.str.encode(self.OUTPUT_ENCODING)
 
     def string_simple_split(self, field, separators, new_field_names,
                             keep_original=True, inplace=False):
@@ -620,12 +622,12 @@ Método que llamó al normalizador de campos: {}
     def _split(value, separators):
         values = []
         for separator in separators:
-            if separator in six.u(value):
-                values = [six.u(split_value) for split_value in
+            if separator in six.text_type(value):
+                values = [six.text_type(split_value) for split_value in
                           value.split(separator)]
                 break
 
-        return pd.Series([six.u(value).strip() for value in values
+        return pd.Series([six.text_type(value).strip() for value in values
                           if pd.notnull(value)])
 
     def string_regex_split(self, field, pattern, new_field_names,
@@ -688,7 +690,7 @@ Método que llamó al normalizador de campos: {}
         except:
             values = []
 
-        values = [six.u(split_value) for split_value in values]
+        values = [six.text_type(split_value) for split_value in values]
 
         return pd.Series(values)
 
@@ -775,7 +777,7 @@ Método que llamó al normalizador de campos: {}
                 print(res['error'])
 
             if keep_original:
-                field_normalized = six.u(field + '_normalized')
+                field_normalized = six.text_type(field + '_normalized')
                 self._update_column(field_normalized, NAME, entity_level, res)
             else:
                 self._update_column(field, NAME, entity_level, res)

--- a/data_cleaner/data_cleaner.py
+++ b/data_cleaner/data_cleaner.py
@@ -180,7 +180,7 @@ class DataCleaner(object):
         if field != norm_field:
             caller_rule = self._get_normalize_field_caller(
                 inspect.currentframe())
-            msg = """
+            msg = u"""
 
 El campo "{}" no sigue las convenciones para escribir
 campos (sólo se admiten caracteres alfanuméricos ASCII en
@@ -190,7 +190,7 @@ que puede llevar a resultados inesperados.
 
 El nuevo nombre del campo normalizado es: "{}".
 Método que llamó al normalizador de campos: {}
-""".format(field, sep, norm_field, caller_rule).encode("utf-8")
+""".format(field, sep, norm_field, caller_rule)
             warnings.warn(msg)
 
         return norm_field

--- a/data_cleaner/fingerprint_keyer.py
+++ b/data_cleaner/fingerprint_keyer.py
@@ -54,11 +54,11 @@ def fingerprint_keyer(key_string, sort_tokens=False, remove_duplicates=False):
         sorted_split_key = dups_removed
 
     # join the tokens back together
-    finger_printed_key = " ".join(sorted_split_key)
+    finger_printed_key = u" ".join(sorted_split_key)
 
     # normalize extended western characters to their ASCII
     # representation (for example "gödel" → "godel")
-    finger_printed_key = unidecode(finger_printed_key.decode("utf-8"))
+    finger_printed_key = unidecode(finger_printed_key)
 
     return finger_printed_key
 

--- a/data_cleaner/fingerprint_keyer.py
+++ b/data_cleaner/fingerprint_keyer.py
@@ -26,21 +26,17 @@ def fingerprint_keyer(key_string, sort_tokens=False, remove_duplicates=False):
         return pd.np.nan
 
     # enforece string type
-    if not isinstance(key_string, six.binary_type):
-        key_string = six.text_type(key_string).encode('utf8')
+    if not isinstance(key_string, six.text_type):
+        key_string = six.text_type(key_string)
 
     # remove leading and trailing whitespace, go to lowercase
     key_string = key_string.strip().lower()
 
     # remove all punctuation and control characters
-    empty_str = six.text_type('').encode('utf8')
-    for punct in (set(key_string) & set(six.text_type(string.punctuation).encode('utf8'))):
-        if six.PY3:
-            punct = chr(punct)
-        encoded_punct = six.text_type(punct).encode('utf8')
-        key_string = key_string.replace(encoded_punct, empty_str)
+    for punct in (set(key_string) & set(string.punctuation)):
+        key_string = key_string.replace(punct, "")
 
-    key_string = key_string.replace(u"\t".encode('utf8'), u" ".encode('utf8'))
+    key_string = key_string.replace("\t", " ")
 
     # split the string into whitespace-separated tokens
     split_key = key_string.split()
@@ -59,13 +55,11 @@ def fingerprint_keyer(key_string, sort_tokens=False, remove_duplicates=False):
         sorted_split_key = dups_removed
 
     # join the tokens back together
-    finger_printed_key = u" ".encode('utf8').join(sorted_split_key)
+    finger_printed_key = " ".join(sorted_split_key)
 
     # normalize extended western characters to their ASCII
     # representation (for example "gödel" → "godel")
-    finger_printed_key = unidecode(finger_printed_key.decode("utf-8"))
-
-    return finger_printed_key
+    return unidecode(finger_printed_key)
 
 
 def group_fingerprint_strings(raw_strs, sort_tokens=False,

--- a/data_cleaner/georef_api.py
+++ b/data_cleaner/georef_api.py
@@ -58,7 +58,7 @@ class GeorefWrapper:
 
         for row in data:
             r = requests.post(resource, json=row)
-            if b'resultados' in r.content:
+            if 'resultados' in r.content.decode('utf8'):
                 result_partial.append(json.loads(r.content)['resultados'])
             else:
                 error = self._get_first_error(json.loads(r.content)['errores'])

--- a/data_cleaner/georef_api.py
+++ b/data_cleaner/georef_api.py
@@ -58,7 +58,7 @@ class GeorefWrapper:
 
         for row in data:
             r = requests.post(resource, json=row)
-            if 'resultados' in r.content:
+            if b'resultados' in r.content:
                 result_partial.append(json.loads(r.content)['resultados'])
             else:
                 error = self._get_first_error(json.loads(r.content)['errores'])
@@ -76,7 +76,7 @@ class GeorefWrapper:
     @staticmethod
     def _getrows_byslice(entity, seq, rowlen):
         data_slice = []
-        for start in xrange(0, len(seq), rowlen):
+        for start in range(0, len(seq), rowlen):
             data_slice.append({entity: seq[start:start + rowlen]})
         return data_slice
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,7 @@ from recommonmark.parser import CommonMarkParser
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.dirname(os.path.abspath('.')))
-sys.path.insert(0, os.path.join(
-    [os.path.dirname(os.path.abspath('.')), "data_cleaner"]))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath('.')), "data_cleaner"))
 
 # -- General configuration ------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chardet==3.0.4
+cchardet==2.1.4
 pandas==0.20.3
 geopandas==0.2.1
 parsley>=1.2
@@ -13,3 +13,4 @@ xlrd
 pycrs
 requests
 six>=1.12.0
+future==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ unicodecsv>=0.14.1
 xlrd
 pycrs
 requests
+six>=1.12.0

--- a/tests/input/to_clean_fields.csv
+++ b/tests/input/to_clean_fields.csv
@@ -1,1 +1,1 @@
-campo_ok_1,campook2,Campo Error 1,CampoError2,campóerror3,campo*error4,campo error 5
+campo_ok_1,campook2,Campo Error 1,CampoError2,campóerror3,campo*error4,campo error 5,ñandu,más caracteres

--- a/tests/output/clean_fields.csv
+++ b/tests/output/clean_fields.csv
@@ -1,1 +1,1 @@
-campo_ok_1,campook2,campo_error_1,campo_error2,campoerror3,campoerror4,campo_error_5
+campo_ok_1,campook2,campo_error_1,campo_error2,campoerror3,campoerror4,campo_error_5,nandu,mas_caracteres

--- a/tests/test_capitalizer.py
+++ b/tests/test_capitalizer.py
@@ -12,6 +12,9 @@ from __future__ import with_statement
 import unittest
 import nose
 
+import sys
+sys.path.insert(0, '')
+
 from data_cleaner.capitalizer import normalize_word
 from data_cleaner.capitalizer import capitalize
 

--- a/tests/test_data_cleaner.py
+++ b/tests/test_data_cleaner.py
@@ -16,6 +16,8 @@ import os
 import pandas as pd
 import vcr
 import geopandas as gpd
+import sys
+sys.path.insert(0, '')
 from data_cleaner import DataCleaner
 from data_cleaner.data_cleaner import DuplicatedField
 from .rules.integration import rules
@@ -53,7 +55,7 @@ def nan_safe_list(iterable):
             else:
                 safe_list.append(element)
         else:
-            safe_list.append(six.u(int(element)))
+            safe_list.append(six.text_type(int(element)))
 
     return safe_list
 
@@ -64,7 +66,7 @@ def nan_to_empty_string_list(iterable):
 
 
 def raw_csv(file_path):
-    with open(file_path, 'rb') as csvfile:
+    with open(file_path, 'r') as csvfile:
         return [row for row in csv.reader(csvfile)]
 
 

--- a/tests/test_data_cleaner.py
+++ b/tests/test_data_cleaner.py
@@ -18,7 +18,7 @@ import vcr
 import geopandas as gpd
 from data_cleaner import DataCleaner
 from data_cleaner.data_cleaner import DuplicatedField
-from rules.integration import rules
+from .rules.integration import rules
 import csv
 
 BASE_DIR = os.path.dirname(__file__)

--- a/tests/test_data_cleaner.py
+++ b/tests/test_data_cleaner.py
@@ -20,6 +20,7 @@ from data_cleaner import DataCleaner
 from data_cleaner.data_cleaner import DuplicatedField
 from .rules.integration import rules
 import csv
+import six
 
 BASE_DIR = os.path.dirname(__file__)
 VCR = vcr.VCR(path_transformer=vcr.VCR.ensure_suffix('.yaml'),
@@ -46,13 +47,13 @@ def nan_safe_list(iterable):
     for element in iterable:
         if pd.isnull(element):
             safe_list.append(None)
-        elif (type(element) is str or type(element) is unicode):
+        elif isinstance(element, six.string_types):
             if element == "None":
                 safe_list.append(None)
             else:
                 safe_list.append(element)
         else:
-            safe_list.append(unicode(int(element)))
+            safe_list.append(six.u(int(element)))
 
     return safe_list
 

--- a/tests/test_fingerprint_keyer.py
+++ b/tests/test_fingerprint_keyer.py
@@ -12,6 +12,9 @@ from __future__ import with_statement
 import unittest
 import nose
 
+import sys
+sys.path.insert(0, '')
+
 from data_cleaner.fingerprint_keyer import fingerprint_keyer
 from data_cleaner.fingerprint_keyer import group_fingerprint_strings
 from data_cleaner.fingerprint_keyer import get_best_replacements


### PR DESCRIPTION
Los cambios estuvieron basados en la guia de python-future acerca de [cómo escribir código compatible con python 2 y 3](https://python-future.org/compatible_idioms.html) y la [documentación de six](https://six.readthedocs.io/)
Testeado con python 2.7.15 y 3.6.3

Tipos de cambios:
- Cambio imports relativos a una sintaxis soportada por py2 y py3
- `map` ya no devuelve una lista en py3
- `__func__` y `xrange` ya no existen en py3
- Uso `six` para manejar las diferencias de `bytes`, `str` y `unicode` entre py2 y py3
- `iteritems()` hay que importarlo en py3
